### PR TITLE
python 3 compatibility

### DIFF
--- a/twokenize.py
+++ b/twokenize.py
@@ -19,11 +19,11 @@ There have been at least 2 other Java ports, but they are not in the lineage for
 
 Ported to Python by Myle Ott <myleott@gmail.com>.
 """
+from __future__ import unicode_literals
 
 import operator
 import re
 import sys
-from __future__ import unicode_literals
 
 try:
     from html.parser import HTMLParser


### PR DESCRIPTION
Hi Myle, 

twokenize.py should be Python 2 and 3 compatible with these commits. Sorry about the last pull request, I found a bug after creating that pull request. I have fixed it now. 

One more thing. The name of the repo has hyphens in it. When I clone it and try to make it into a package by putting a **init**.py file in the repo, Python complains since it doesn't like hyphens in package names. Maybe it's a good idea to replace the hyphens with underscores?

-Dibya
